### PR TITLE
[Feat] 엔티티 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.h2database:h2'

--- a/src/main/java/com/kuit/healthmate/domain/Habit.java
+++ b/src/main/java/com/kuit/healthmate/domain/Habit.java
@@ -1,0 +1,21 @@
+package com.kuit.healthmate.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "habits")
+public class Habit {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "habit_id")
+    private Long id;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="user_id")
+    private User user;
+
+}

--- a/src/main/java/com/kuit/healthmate/domain/HabitChecker.java
+++ b/src/main/java/com/kuit/healthmate/domain/HabitChecker.java
@@ -1,0 +1,4 @@
+package com.kuit.healthmate.domain;
+
+public class HabitChecker {
+}

--- a/src/main/java/com/kuit/healthmate/domain/HabitTime.java
+++ b/src/main/java/com/kuit/healthmate/domain/HabitTime.java
@@ -1,0 +1,4 @@
+package com.kuit.healthmate.domain;
+
+public class HabitTime {
+}

--- a/src/main/java/com/kuit/healthmate/domain/Supplement.java
+++ b/src/main/java/com/kuit/healthmate/domain/Supplement.java
@@ -1,0 +1,21 @@
+package com.kuit.healthmate.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "supplements")
+public class Supplement {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "supplement_id")
+    private Long id;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="user_id")
+    private User user;
+
+}

--- a/src/main/java/com/kuit/healthmate/domain/SupplementChecker.java
+++ b/src/main/java/com/kuit/healthmate/domain/SupplementChecker.java
@@ -1,0 +1,4 @@
+package com.kuit.healthmate.domain;
+
+public class SupplementChecker {
+}

--- a/src/main/java/com/kuit/healthmate/domain/SupplementTime.java
+++ b/src/main/java/com/kuit/healthmate/domain/SupplementTime.java
@@ -1,0 +1,4 @@
+package com.kuit.healthmate.domain;
+
+public class SupplementTime {
+}

--- a/src/main/java/com/kuit/healthmate/domain/User.java
+++ b/src/main/java/com/kuit/healthmate/domain/User.java
@@ -24,8 +24,11 @@ public class User {
     @Column(nullable = false,name = "nickname")
     private String nickname;
 
-    @OneToMany(mappedBy = "gameCharacter",cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "user",cascade = CascadeType.ALL)
     private List<Habit> habits = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user",cascade = CascadeType.ALL)
+    private List<Supplement> supplements = new ArrayList<>();
 
     @Column(name = "status")
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/kuit/healthmate/domain/User.java
+++ b/src/main/java/com/kuit/healthmate/domain/User.java
@@ -1,0 +1,36 @@
+package com.kuit.healthmate.domain;
+
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(nullable = false,name = "email")
+    private String email;
+
+    @Column(nullable = false,name = "nickname")
+    private String nickname;
+
+    @OneToMany(mappedBy = "gameCharacter",cascade = CascadeType.ALL)
+    private List<Habit> habits = new ArrayList<>();
+
+    @Column(name = "status")
+    @Enumerated(EnumType.STRING)
+    private UserStatus status;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/kuit/healthmate/domain/UserStatus.java
+++ b/src/main/java/com/kuit/healthmate/domain/UserStatus.java
@@ -1,0 +1,5 @@
+package com.kuit.healthmate.domain;
+
+public enum UserStatus {
+    ADMIN, GENERAL
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,9 +2,27 @@ spring:
   application:
     name: health-mate
   datasource:
-    url: jdbc:h2:mem:testdb
     driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:test
     username: sa
     password:
+
+  h2:
+    console:
+      enabled: true
+      settings:
+        web-allow-others: true
+      path: /h2-console
+
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: update        # DB 초기화 전략 (none, create, create-drop, update, validate)
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        format_sql: true      # 쿼리 로그 포맷 (정렬)
+        show_sql: true        # 쿼리 로그 출력
+        generate-ddl: true
 server:
-  port: 8090
+  port: 9000


### PR DESCRIPTION
### ✏️ 작업 개요
현재 사용할 엔티티들 생성

### ⛳ 작업 분류
- [x] 각 entity 클래스 생성
- [x] user, habit, supplement 간단 세팅

### 🔨 작업 상세 내용
1. user, habit, supplement에 대한 엔티티 세팅을 간단히 해보았습니다.

### 💡 생각해볼 문제
- 정말 간단하게 세팅을 해두었습니다. 더 많은 세팅을 안한 이유는 각자 맡은 도메인을 개발하면서 jpa와 orm에 대해 익숙해지는 시간을 가졌으면 하는 마음에 이렇게 세팅합니다. jpa에서 연관관계 매핑이나 1:1, 1:n, n:n 상황에서 어떻게 처리할지 고민하는 시간을 가져보면 좋을거 같습니다.
- 또한 지금은 따로 패키지를 분리하지 않았지만 도메인 별로 해당 엔티티들을 넣어두는 구조가 이상적일거 같습니다.