### PR TITLE
[Refactor] : 습관 조회 API

### DIFF
--- a/src/main/java/com/kuit/healthmate/challenge/habit/controller/habitController.java
+++ b/src/main/java/com/kuit/healthmate/challenge/habit/controller/habitController.java
@@ -32,7 +32,7 @@ public class habitController {
      * 습관 챌린지 조회
      */
     @GetMapping("/{userId}")
-    public ApiResponse<List<GetHabitResponse>> findHabitChallenge(@RequestBody GetHabitRequest getHabitRequest , @PathVariable long userId) {
+    public ApiResponse<List<Habit>> findHabitChallenge(@RequestBody GetHabitRequest getHabitRequest , @PathVariable long userId) {
         return new ApiResponse<>(habitService.getActiveHabitsByUserIdAndToday(userId,LocalDate.parse(getHabitRequest.getDate(), FORMATTER)));
     }
     /**

--- a/src/main/java/com/kuit/healthmate/challenge/habit/domain/HabitChecker.java
+++ b/src/main/java/com/kuit/healthmate/challenge/habit/domain/HabitChecker.java
@@ -6,6 +6,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -17,7 +18,7 @@ public class HabitChecker {
     private Long id;
 
     @NotNull
-    private LocalDateTime createdAt;
+    private LocalDate createdAt;
     
     private Boolean status;
 
@@ -30,7 +31,7 @@ public class HabitChecker {
     }
 
     @Builder
-    public HabitChecker(Long id, LocalDateTime createdAt, Boolean status, Habit habit){
+    public HabitChecker(Long id, LocalDate createdAt, Boolean status, Habit habit){
         this.id = id;
         this.createdAt = createdAt;
         this.status = status;

--- a/src/main/java/com/kuit/healthmate/challenge/habit/dto/PutCheckHabitRequest.java
+++ b/src/main/java/com/kuit/healthmate/challenge/habit/dto/PutCheckHabitRequest.java
@@ -2,8 +2,10 @@ package com.kuit.healthmate.challenge.habit.dto;
 
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
+
+
 @Getter
 public class PutCheckHabitRequest {
-    LocalDateTime date;
+    LocalDate date;
 }

--- a/src/main/java/com/kuit/healthmate/challenge/habit/repository/HabitRepository.java
+++ b/src/main/java/com/kuit/healthmate/challenge/habit/repository/HabitRepository.java
@@ -18,7 +18,7 @@ public interface HabitRepository  extends JpaRepository<Habit, Long> {
     @Query("SELECT h FROM Habit h LEFT JOIN FETCH h.habitChecker WHERE h.id = :habitId")
     List<Habit> findByIdWithHabitCheckers(@Param("habitId") Long habitId);
 
-    @Query("SELECT h FROM Habit h WHERE h.user.id = :userId AND h.status = 'ACTIVE' AND SUBSTRING(h.selectedDay, :dayOfWeek, 1) = '1'")
+    @Query("SELECT h FROM Habit h join fetch h.habitChecker hc WHERE h.user.id = :userId AND h.status = 'ACTIVE' AND SUBSTRING(h.selectedDay, :dayOfWeek, 1) = '1'")
     List<Habit> findActiveHabitsByUserIdAndDayOfWeek(@Param("userId") Long userId, @Param("dayOfWeek") int dayOfWeek);
 
     @Query("SELECT DISTINCT h from Habit h join fetch h.habitChecker hc WHERE h.user.id= :userId and hc.createdAt between :startDate and :endDate")

--- a/src/main/java/com/kuit/healthmate/challenge/habit/repository/HabitRepository.java
+++ b/src/main/java/com/kuit/healthmate/challenge/habit/repository/HabitRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -20,6 +21,10 @@ public interface HabitRepository  extends JpaRepository<Habit, Long> {
     @Query("SELECT h FROM Habit h WHERE h.user.id = :userId AND h.status = 'ACTIVE' AND SUBSTRING(h.selectedDay, :dayOfWeek, 1) = '1'")
     List<Habit> findActiveHabitsByUserIdAndDayOfWeek(@Param("userId") Long userId, @Param("dayOfWeek") int dayOfWeek);
 
+    @Query("SELECT DISTINCT h from Habit h join fetch h.habitChecker hc WHERE h.user.id= :userId and hc.createdAt between :startDate and :endDate")
+    List<Habit> findAllByUserIdAndCreatedAtBetween(@Param("userId") Long userId,
+                                                   @Param("startDate") LocalDate startDate,
+                                                   @Param("endDate") LocalDate endDate);
     @Modifying
     @Query("update Habit h set h.status = 'INACTIVE' where h.id = :habitId")
     void updateHabitStatus(@Param("habitId") Long habitId);

--- a/src/main/java/com/kuit/healthmate/challenge/habit/service/HabitService.java
+++ b/src/main/java/com/kuit/healthmate/challenge/habit/service/HabitService.java
@@ -52,17 +52,21 @@ public class HabitService {
         return habitRepository.save(habit);
     }
 
+    //특정 날짜 기준 조회 ,,당일 or 특정 날짜
     @Transactional(readOnly = true)
-    public List<GetHabitResponse> getActiveHabitsByUserIdAndToday(Long userId, LocalDate date) {
+    public List<Habit> getActiveHabitsByUserIdAndToday(Long userId, LocalDate date) {
         int dayOfWeek = date.getDayOfWeek().getValue();
         // 요일을 월요일부터 시작하는 1부터 7까지의 값으로 맞추기 위해 필요
         // 월요일이 1, 화요일이 2, ..., 일요일이 7
-        List<GetHabitResponse> habits = habitRepository.findActiveHabitsByUserIdAndDayOfWeek(userId, dayOfWeek)
-                .stream()
-                .map(GetHabitResponse::new)
-                .collect(Collectors.toList());
-        return habits;
+        return habitRepository.findActiveHabitsByUserIdAndDayOfWeek(userId, dayOfWeek);
     }
+    public List<Habit> getHabitForWeek(Long userId, LocalDate startDate,LocalDate endDate){
+        return habitRepository.findAllByUserIdAndCreatedAtBetween(userId,startDate,endDate);
+    }
+    public List<Habit> getHabitForMonth(Long userId, LocalDate endDate){
+        return habitRepository.findAllByUserIdAndCreatedAtBetween(userId, endDate.withDayOfMonth(1),endDate);
+    }
+
     @Transactional
     public void updateHabit(PatchEditHabitRequest patchEditHabitRequest){
         Long habitId = patchEditHabitRequest.getHabitId();
@@ -85,7 +89,7 @@ public class HabitService {
         habitRepository.updateHabitStatus(habitId);
     }
     @Transactional
-    public void checkHabit(LocalDateTime date, Long habitId) {
+    public void checkHabit(LocalDate date, Long habitId) {
         Habit habit = habitRepository.findById(habitId)
                 .orElseThrow(() -> new HabitException(ExceptionResponseStatus.NOT_EXIST_HABIT));
 


### PR DESCRIPTION
### ✏️ 작업 개요
습관 조회를 일간, 주간, 월간 별로 나누었습니다. 

### ⛳ 작업 분류
- [x] 일간 로직 수정
- [x] 주간, 월간 로직 작성

### 🔨 작업 상세 내용
1. 일간 조회에서 DTO를 엔티티로 반환하도록 수정하였습니다.
2. 일간 조회에서 join fetch를 사용하여서 habitChecker까지 가져오도록 수정하였습니다.
3. 주간, 월간 조회하는 로직을 태완님이 사용하신 startDate, endDate를 사용하신 부분을 참고하여 작성하였습니다.

### 💡 생각해볼 문제
- 태완님이 사용하신 주간 월간 조회 쿼리문에서는
`@Query("select distinct s from Supplement s join fetch s.supplementCheckers sc where s.user.id = :userId and sc.checkDate between :startDate and :endDate")`
supplementChecker가 존재하고 체크한 날짜가 between startDate 와 endDate사이에 있어야지 조회가 되는 경우인데 
저번주 회의에서 정한 방식인, 챌린지 Checker가 사용자가 수행 완료 버튼을 수행한 뒤 생성되도록 하는 방법인 경우 Checker가 생성되지 않은 챌린지의 경우 조회되지 않는 문제가 있을 것 같다고 생각합니다.