### PR TITLE
[Feat]  건강진단 엔티티 생성

### DIFF
--- a/src/main/java/com/kuit/healthmate/diagnosis/dto/LifeStyleDto.java
+++ b/src/main/java/com/kuit/healthmate/diagnosis/dto/LifeStyleDto.java
@@ -1,0 +1,10 @@
+package com.kuit.healthmate.diagnosis.dto;
+
+public class LifeStyleDto {
+    private int environmentScore;
+    private int focusTimeScore;
+    private int coffeeConsumptionScore;
+    private int exerciseTimeScore;
+    private int postureDiscomfortScore;
+}
+

--- a/src/main/java/com/kuit/healthmate/diagnosis/dto/MealPatternDto.java
+++ b/src/main/java/com/kuit/healthmate/diagnosis/dto/MealPatternDto.java
@@ -1,0 +1,12 @@
+package com.kuit.healthmate.diagnosis.dto;
+
+public class MealPatternDto {
+    private int mealTimeScore;
+    private int foodType;
+    private int regularMealTimeScore;
+    private int mealDurationScore;
+    private int seasoningConsumptionScore;
+    private int screenUsage;
+    private int mealRemark;
+}
+

--- a/src/main/java/com/kuit/healthmate/diagnosis/dto/PostDiagnosisRequest.java
+++ b/src/main/java/com/kuit/healthmate/diagnosis/dto/PostDiagnosisRequest.java
@@ -1,0 +1,22 @@
+package com.kuit.healthmate.diagnosis.dto;
+
+import com.kuit.healthmate.diagnosis.symtom.domain.SymptomInfo;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public class PostDiagnosisRequest {
+    @NotNull(message = "lifeStyleDto: {Notnull}")
+    LifeStyleDto lifeStyleDto;
+
+    @NotNull(message = "mealPatternDto: {Notnull}")
+    MealPatternDto mealPatternDto;
+
+    @NotNull(message = "sleepPatternDto: {Notnull}")
+    SleepPatternDto sleepPatternDto;
+
+    @NotNull(message = "symptomInfos: {Notnull}")
+    List<SymptomInfo> symptomInfos;
+
+}
+

--- a/src/main/java/com/kuit/healthmate/diagnosis/dto/SleepPatternDto.java
+++ b/src/main/java/com/kuit/healthmate/diagnosis/dto/SleepPatternDto.java
@@ -1,0 +1,8 @@
+package com.kuit.healthmate.diagnosis.dto;
+
+public class SleepPatternDto {
+    private int sleepDurationScore;
+    private int morningFatigueScore;
+    private int peakConditionTimeScore;
+    private int sleepRemarkScore;
+}

--- a/src/main/java/com/kuit/healthmate/diagnosis/life/domain/LifeStyleQuestionnaire.java
+++ b/src/main/java/com/kuit/healthmate/diagnosis/life/domain/LifeStyleQuestionnaire.java
@@ -1,0 +1,49 @@
+package com.kuit.healthmate.diagnosis.life.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "lifeStyle")
+@Getter
+public class LifeStyleQuestionnaire {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 규칙적/불규칙적 점수
+    @Column(nullable = false)
+    private int environmentScore;
+
+    // 집중 시간 점수
+    @Column(nullable = false)
+    private int focusTimeScore;
+
+    // 커피 소비 점수
+    @Column(nullable = false)
+    private int coffeeConsumptionScore;
+
+    // 운동 시간 점수
+    @Column(nullable = false)
+    private int exerciseTimeScore;
+
+    //허리 자세 불편함 점수
+    @Column(nullable = false)
+    private int postureDiscomfortScore;
+
+    // 설문 조사 날짜 및 시간
+    @Column(nullable = false)
+    private LocalDateTime timestamp;
+
+    // 총합 계산 메소드
+    public int calculateTotalScore() {
+        return environmentScore + focusTimeScore + coffeeConsumptionScore + exerciseTimeScore + postureDiscomfortScore;
+    }
+
+}

--- a/src/main/java/com/kuit/healthmate/diagnosis/meal/domain/MealPatternQuestionnaire.java
+++ b/src/main/java/com/kuit/healthmate/diagnosis/meal/domain/MealPatternQuestionnaire.java
@@ -1,0 +1,56 @@
+package com.kuit.healthmate.diagnosis.meal.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "mealPattern")
+@Getter
+public class MealPatternQuestionnaire {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 식사 시간 점수 (아침, 점심, 저녁)
+    @Column(nullable = false)
+    private int mealTimeScore;
+
+    // 음식 종류 (한식, 일식, 중식, 양식, 기타)
+    @Column(nullable = false)
+    private int foodType;
+
+    // 식사 시간의 규칙성 점수
+    @Column(nullable = false)
+    private int regularMealTimeScore;
+
+    // 한 끼 식사에 소요된 시간 점수
+    @Column(nullable = false)
+    private int mealDurationScore;
+
+    // 조미료 섭취 점수
+    @Column(nullable = false)
+    private int seasoningConsumptionScore;
+
+    // 식사 중 TV나 스마트폰 사용 여부
+    @Column(nullable = false)
+    private int screenUsage;
+
+    // 식사 도중 느낀 특이점
+    @Column(nullable = false)
+    private int mealRemark;
+
+    // 설문 조사 날짜 및 시간
+    @Column(nullable = false)
+    private LocalDateTime timestamp;
+
+    // 총합 계산 메소드
+    public int calculateTotalScore() {
+        return mealTimeScore + regularMealTimeScore + mealDurationScore + seasoningConsumptionScore;
+    }
+}

--- a/src/main/java/com/kuit/healthmate/diagnosis/sleep/domain/SleepPatternQuestionnaire.java
+++ b/src/main/java/com/kuit/healthmate/diagnosis/sleep/domain/SleepPatternQuestionnaire.java
@@ -1,0 +1,44 @@
+package com.kuit.healthmate.diagnosis.sleep.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "sleepPattern")
+@Getter
+public class SleepPatternQuestionnaire {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 수면 시간 점수
+    @Column(nullable = false)
+    private int sleepDurationScore;
+
+    // 아침 피로도 점수
+    @Column(nullable = false)
+    private int morningFatigueScore;
+
+    // 하루 컨디션이 최고인 시간 점수
+    @Column(nullable = false)
+    private int peakConditionTimeScore;
+
+    // 수면 중 특이사항 점수
+    @Column(nullable = false)
+    private int sleepRemarkScore;
+
+    // 설문 조사 날짜 및 시간
+    @Column(nullable = false)
+    private LocalDateTime timestamp;
+
+    // 총합 계산 메소드
+    public int calculateTotalScore() {
+        return sleepDurationScore + morningFatigueScore + peakConditionTimeScore + sleepRemarkScore;
+    }
+}

--- a/src/main/java/com/kuit/healthmate/diagnosis/symtom/domain/SymptomInfo.java
+++ b/src/main/java/com/kuit/healthmate/diagnosis/symtom/domain/SymptomInfo.java
@@ -1,0 +1,11 @@
+package com.kuit.healthmate.diagnosis.symtom.domain;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class SymptomInfo {
+
+    private int symptomType; //관련 과에 따라 구분 ex) 피부과, 신경과, 정신과, 기타
+
+    private String symptomName;
+}

--- a/src/main/java/com/kuit/healthmate/diagnosis/symtom/domain/SymptomQuestionnaire.java
+++ b/src/main/java/com/kuit/healthmate/diagnosis/symtom/domain/SymptomQuestionnaire.java
@@ -18,12 +18,24 @@ public class SymptomQuestionnaire {
     private Long id;
 
     @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "symptomType", column = @Column(name = "first_symptomType")),
+            @AttributeOverride(name = "symptomName", column = @Column(name = "first_symptomName"))
+    })
     private SymptomInfo first;
 
     @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "symptomType", column = @Column(name = "second_symptomType")),
+            @AttributeOverride(name = "symptomName", column = @Column(name = "second_symptomName"))
+    })
     private SymptomInfo second;
 
     @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "symptomType", column = @Column(name = "third_symptomType")),
+            @AttributeOverride(name = "symptomName", column = @Column(name = "third_symptomName"))
+    })
     private SymptomInfo third;
 
     @Column(nullable = false)

--- a/src/main/java/com/kuit/healthmate/diagnosis/symtom/domain/SymptomQuestionnaire.java
+++ b/src/main/java/com/kuit/healthmate/diagnosis/symtom/domain/SymptomQuestionnaire.java
@@ -1,0 +1,31 @@
+package com.kuit.healthmate.diagnosis.symtom.domain;
+
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "symptom")
+@Getter
+public class SymptomQuestionnaire {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Embedded
+    private SymptomInfo first;
+
+    @Embedded
+    private SymptomInfo second;
+
+    @Embedded
+    private SymptomInfo third;
+
+    @Column(nullable = false)
+    private LocalDateTime timestamp;
+}


### PR DESCRIPTION
### ✏️ 작업 개요
사용자가 건강진단 문항에서 선택한 값을 저장하는 엔티티를 생성하였습니다.

### ⛳ 작업 분류
- [x] 생활습관, 식습관, 수면패턴, 이상증세 엔티티 생성
- [x] 건강진단 문항 RequestDTO생성 

### 🔨 작업 상세 내용
1. 각각의 문항들을 클라이언트로부터 정수로 받아 사용자가 어떤 선택을 했는지 식별하도록 구현하였습니다.

### 💡 생각해볼 문제
- 클라이어트로부터 문항 응답에 대한 정보를 어떠한 방식으로 GPT한테 보낼지 노션에 정리해서 올리겠습니다.
- 생활습관, 식습관 수면패턴 점수를 어떠한 방식으로 계산할지 토의해보면 좋을 것 같습니다.