### PR TITLE
[Docs] swagger setup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,10 @@ repositories {
 }
 
 dependencies {
+    //swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.11'
+
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter'

--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,7 @@ repositories {
 
 dependencies {
     //swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
-    implementation 'org.springdoc:springdoc-openapi-ui:1.6.11'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/com/kuit/healthmate/config/SwaggerConfig.java
+++ b/src/main/java/com/kuit/healthmate/config/SwaggerConfig.java
@@ -1,0 +1,24 @@
+package com.kuit.healthmate.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Springdoc 테스트")
+                .description("Springdoc을 사용한 Swagger UI 테스트")
+                .version("1.0.0");
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,18 @@ spring:
     url: jdbc:h2:mem:test;mode=mysql
     username: sa
     password:
-
+springdoc:
+  packages-to-scan: com.kuit.healthmate
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    path: /API-doc
+    url: /v3/api-docs
+    disable-swagger-default-url: true
+    display-request-duration: true
+    operations-sorter: alpha
+  api-docs:
+    path: /v3/api-docs
   h2:
     console:
       enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -76,5 +76,17 @@ spring:
       data-locations: classpath*:test.sql
       mode: always
       platform: h2
+springdoc:
+  packages-to-scan: com.kuit.healthmate
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    path: /API-doc
+    url: /v3/api-docs
+    disable-swagger-default-url: true
+    display-request-duration: true
+    operations-sorter: alpha
+  api-docs:
+    path: /v3/api-docs
 server:
   port: 9000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,18 +9,6 @@ spring:
     url: jdbc:h2:mem:test;mode=mysql
     username: sa
     password:
-springdoc:
-  packages-to-scan: com.kuit.healthmate
-  default-consumes-media-type: application/json;charset=UTF-8
-  default-produces-media-type: application/json;charset=UTF-8
-  swagger-ui:
-    path: /API-doc
-    url: /v3/api-docs
-    disable-swagger-default-url: true
-    display-request-duration: true
-    operations-sorter: alpha
-  api-docs:
-    path: /v3/api-docs
   h2:
     console:
       enabled: true
@@ -38,6 +26,18 @@ springdoc:
         format_sql: true      # 쿼리 로그 포맷 (정렬)
         show_sql: true        # 쿼리 로그 출력
         generate-ddl: true
+springdoc:
+  packages-to-scan: com.kuit.healthmate
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    path: /API-doc
+    url: /v3/api-docs
+    disable-swagger-default-url: true
+    display-request-duration: true
+    operations-sorter: alpha
+  api-docs:
+    path: /v3/api-docs
 server:
   port: 9000
 ---


### PR DESCRIPTION
### ✏️ 작업 개요
swagger ui 를 사용하기 위한 의존성 추가 및 config 파일 추가하였습니다.

### ⛳ 작업 분류
- [x] 의존성 추가 
- [x] SwaggerConfig 추가

### 🔨 작업 상세 내용
1. 스프링 부트에서 swagger를 사용하는 방법으로 spring doc, spring fox 두가지가 있다고 하는데, spring doc가 최근에 많이 쓰이는 추세라고 하여서 이를 사용하여 구현하였습니다. 
2.  `/API-doc`  path를 통해 접근 가능합니다.

### 💡 생각해볼 문제
- swagger -ui 속성으로 더 추가할 내용은 없는가?