### PR TITLE
[Refactor] supplement api 테스트 및 리팩토링

### DIFF
--- a/src/main/java/com/kuit/healthmate/HealthMateApplication.java
+++ b/src/main/java/com/kuit/healthmate/HealthMateApplication.java
@@ -1,9 +1,12 @@
 package com.kuit.healthmate;
 
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+
 @SpringBootApplication
+@EnableBatchProcessing
 public class HealthMateApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/kuit/healthmate/challenge/common/service/CommonChallengeServiceImpl.java
+++ b/src/main/java/com/kuit/healthmate/challenge/common/service/CommonChallengeServiceImpl.java
@@ -107,7 +107,7 @@ public class CommonChallengeServiceImpl implements CommonChallengeService{
         double achievementRate = 0;
         double totalAchievement = 0;
 
-        List<Supplement> supplements = supplementService.getSupplementForWeek(userId,startDate,endDate);
+        List<Supplement> supplements = supplementService.getSupplementBetween(userId,startDate,endDate);
         List<Habit> habits = habitService.getHabitForWeek(userId, startDate, endDate);
 
         Map<LocalDate, List<SupplementItem>> supplementsByDate = new HashMap<>();
@@ -158,7 +158,7 @@ public class CommonChallengeServiceImpl implements CommonChallengeService{
         double achievementRate = 0;
         double totalAchievement = 0;
 
-        List<Supplement> supplements = supplementService.getSupplementForWeek(userId,startDate,endDate);
+        List<Supplement> supplements = supplementService.getSupplementBetween(userId,startDate,endDate);
         List<Habit> habits = habitService.getHabitForWeek(userId, startDate, endDate);
 
         Map<LocalDate, List<SupplementItem>> supplementsByDate = new HashMap<>();

--- a/src/main/java/com/kuit/healthmate/challenge/supplement/controller/SupplementController.java
+++ b/src/main/java/com/kuit/healthmate/challenge/supplement/controller/SupplementController.java
@@ -29,12 +29,6 @@ public class SupplementController {
 
     private final SupplementService supplementService;
 
-
-    @GetMapping("/{userId}")
-    public ApiResponse<List<SupplementResponse>> getSupplementByUserId(@PathVariable Long userId) {
-        return new ApiResponse<>(supplementService.getSupplementChallengesByUserId(userId));
-    }
-
     @PostMapping("")
     public ApiResponse<Long> registerSupplement(@RequestBody SupplementRegisterRequest supplementRegisterRequest) {
         return new ApiResponse<>(supplementService.registerSupplement(supplementRegisterRequest));

--- a/src/main/java/com/kuit/healthmate/challenge/supplement/controller/SupplementController.java
+++ b/src/main/java/com/kuit/healthmate/challenge/supplement/controller/SupplementController.java
@@ -54,10 +54,4 @@ public class SupplementController {
                 supplementService.checkSupplementChecker(supplementId, supplementCheckerRequest)
         );
     }
-
-    @PostMapping("/error")
-    public void errorTest() {
-        throw new SupplementException(ExceptionResponseStatus.INVALID_SUPPLEMENT_ID);
-//        throw new UserException(ExceptionResponseStatus.INVALID_SUPPLEMENT_ID);
-    }
 }

--- a/src/main/java/com/kuit/healthmate/challenge/supplement/controller/SupplementController.java
+++ b/src/main/java/com/kuit/healthmate/challenge/supplement/controller/SupplementController.java
@@ -1,5 +1,6 @@
 package com.kuit.healthmate.challenge.supplement.controller;
 
+import com.kuit.healthmate.auth.jwt.Jwt;
 import com.kuit.healthmate.challenge.supplement.dto.SupplementCheckerRequest;
 import com.kuit.healthmate.challenge.supplement.dto.SupplementRegisterRequest;
 import com.kuit.healthmate.challenge.supplement.dto.SupplementResponse;
@@ -29,9 +30,10 @@ public class SupplementController {
 
     private final SupplementService supplementService;
 
-    @PostMapping("")
-    public ApiResponse<Long> registerSupplement(@RequestBody SupplementRegisterRequest supplementRegisterRequest) {
-        return new ApiResponse<>(supplementService.registerSupplement(supplementRegisterRequest));
+    @PostMapping("/register")
+    public ApiResponse<Long> registerSupplement(@Jwt Long userId,
+                                                @RequestBody SupplementRegisterRequest supplementRegisterRequest) {
+        return new ApiResponse<>(supplementService.registerSupplement(userId, supplementRegisterRequest));
     }
 
     @PutMapping("/edit/{supplementId}")

--- a/src/main/java/com/kuit/healthmate/challenge/supplement/domain/Supplement.java
+++ b/src/main/java/com/kuit/healthmate/challenge/supplement/domain/Supplement.java
@@ -12,6 +12,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
 @ToString
@@ -43,7 +45,10 @@ public class Supplement {
     @Enumerated(EnumType.STRING)
     private Status status;
 
+    @CreationTimestamp
     private LocalDateTime createdAt;
+
+    @UpdateTimestamp
     private LocalDateTime updatedAt;
 
     public Supplement(User user, String name, SupplementRoutine supplementRoutine) {

--- a/src/main/java/com/kuit/healthmate/challenge/supplement/domain/SupplementChecker.java
+++ b/src/main/java/com/kuit/healthmate/challenge/supplement/domain/SupplementChecker.java
@@ -48,7 +48,7 @@ public class SupplementChecker {
     }
 
     @Override
-    public String toString() {
+    public String toString() {  // TODO: 확인 끝났으면 삭제
         return "SupplementChecker{" +
                 "id=" + id +
                 ", checkDate=" + checkDate +

--- a/src/main/java/com/kuit/healthmate/challenge/supplement/dto/SupplementRegisterRequest.java
+++ b/src/main/java/com/kuit/healthmate/challenge/supplement/dto/SupplementRegisterRequest.java
@@ -11,8 +11,6 @@ import lombok.Getter;
 @Getter
 public class SupplementRegisterRequest {
 
-    private Long userId;    // JWT ??
-
     @JsonProperty("id")
     private Long supplementId;
     private String name;

--- a/src/main/java/com/kuit/healthmate/challenge/supplement/dto/SupplementRegisterRequest.java
+++ b/src/main/java/com/kuit/healthmate/challenge/supplement/dto/SupplementRegisterRequest.java
@@ -11,8 +11,6 @@ import lombok.Getter;
 @Getter
 public class SupplementRegisterRequest {
 
-    @JsonProperty("id")
-    private Long supplementId;
     private String name;
 
     private Map<String, Integer> intakeTime;   // 섭취 시간 (식전 1 식후 2, 분 number로)

--- a/src/main/java/com/kuit/healthmate/challenge/supplement/dto/SupplementUpdateRequest.java
+++ b/src/main/java/com/kuit/healthmate/challenge/supplement/dto/SupplementUpdateRequest.java
@@ -15,8 +15,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SupplementUpdateRequest {
 
-    @JsonProperty("id")
-    private Long supplementId;
     private String name;
 
     private Map<String, Integer> intakeTime;   // 섭취 시간 (식전 1 식후 2, 분 number로)

--- a/src/main/java/com/kuit/healthmate/challenge/supplement/dto/SupplementUpdateRequest.java
+++ b/src/main/java/com/kuit/healthmate/challenge/supplement/dto/SupplementUpdateRequest.java
@@ -14,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public class SupplementUpdateRequest {
-    private Long userId;    // JWT ??
 
     @JsonProperty("id")
     private Long supplementId;

--- a/src/main/java/com/kuit/healthmate/challenge/supplement/repository/SupplementRepository.java
+++ b/src/main/java/com/kuit/healthmate/challenge/supplement/repository/SupplementRepository.java
@@ -20,7 +20,7 @@ public interface SupplementRepository extends JpaRepository<Supplement, Long> {
                                                           @Param("startDate") LocalDate startDate,
                                                           @Param("endDate") LocalDate endDate);
 
-    @Query("select distinct s from Supplement s join fetch s.supplementCheckers sc "
+    @Query("select distinct s from Supplement s left join fetch s.supplementCheckers sc "
             + "where s.id = :supplementId")
     Optional<Supplement> findSupplementAndChecker(@Param("supplementId") Long supplementId);
 }

--- a/src/main/java/com/kuit/healthmate/challenge/supplement/service/SupplementService.java
+++ b/src/main/java/com/kuit/healthmate/challenge/supplement/service/SupplementService.java
@@ -15,12 +15,10 @@ import com.kuit.healthmate.global.response.ExceptionResponseStatus;
 import com.kuit.healthmate.challenge.supplement.repository.SupplementCheckerRepository;
 import com.kuit.healthmate.challenge.supplement.repository.SupplementRepository;
 import com.kuit.healthmate.challenge.supplement.repository.SupplementTimeRepository;
-import com.kuit.healthmate.challenge.supplement.dto.SupplementResponse;
 import com.kuit.healthmate.challenge.supplement.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -106,11 +104,7 @@ public class SupplementService {
         return supplementRepository.findAllByUserIdAndCheckedDateBetween(userId, LocalDate.now(), LocalDate.now());
     }
 
-    public List<Supplement> getSupplementForMonth(Long userId, LocalDate endDate) {
-        return supplementRepository.findAllByUserIdAndCheckedDateBetween(userId, endDate.withDayOfMonth(1), endDate);
-    }
-
-    public List<Supplement> getSupplementForWeek(Long userId, LocalDate startDate, LocalDate endDate) {
+    public List<Supplement> getSupplementBetween(Long userId, LocalDate startDate, LocalDate endDate) {
         return supplementRepository.findAllByUserIdAndCheckedDateBetween(userId, startDate, endDate);
     }
 }

--- a/src/main/java/com/kuit/healthmate/challenge/supplement/service/SupplementService.java
+++ b/src/main/java/com/kuit/healthmate/challenge/supplement/service/SupplementService.java
@@ -35,13 +35,6 @@ public class SupplementService {
     private final SupplementCheckerRepository supplementCheckerRepository;
     private final SupplementTimeRepository supplementTimeRepository;
 
-    public List<SupplementResponse> getSupplementChallengesByUserId(Long userId) {
-        return supplementRepository.findAllByUserIdAndStatus(userId, Status.ACTIVE)
-                .stream()
-                .map(SupplementResponse::new)
-                .collect(Collectors.toList());
-    }
-
     @Transactional
     public Long registerSupplement(SupplementRegisterRequest supplementRegisterRequest) {
         User user = userRepository.findById(supplementRegisterRequest.getUserId()).orElseThrow(

--- a/src/main/java/com/kuit/healthmate/challenge/supplement/service/SupplementService.java
+++ b/src/main/java/com/kuit/healthmate/challenge/supplement/service/SupplementService.java
@@ -87,10 +87,10 @@ public class SupplementService {
                 .filter(x -> x.isDateMatch(LocalDate.now()))
                 .filter(x -> x.isTimeSlotMatch(supplementCheckerRequest.getTimeSlot()))
                 .findAny()
-                .orElse(
-                        supplementCheckerRepository.save(
-                                new SupplementChecker(supplement, supplementCheckerRequest.getTimeSlot())
-                        )
+                .orElseGet(
+                        () -> supplementCheckerRepository.save(
+                                    new SupplementChecker(supplement, supplementCheckerRequest.getTimeSlot())
+                            )
                 );
 
         return supplementChecker.toggleStatus();

--- a/src/main/java/com/kuit/healthmate/challenge/supplement/service/SupplementService.java
+++ b/src/main/java/com/kuit/healthmate/challenge/supplement/service/SupplementService.java
@@ -34,8 +34,8 @@ public class SupplementService {
     private final SupplementTimeRepository supplementTimeRepository;
 
     @Transactional
-    public Long registerSupplement(SupplementRegisterRequest supplementRegisterRequest) {
-        User user = userRepository.findById(supplementRegisterRequest.getUserId()).orElseThrow(
+    public Long registerSupplement(Long userId, SupplementRegisterRequest supplementRegisterRequest) {
+        User user = userRepository.findById(userId).orElseThrow(
                 () -> new UserException(ExceptionResponseStatus.INVALID_USER_ID)
         );
         String name = supplementRegisterRequest.getName();
@@ -59,7 +59,7 @@ public class SupplementService {
     @Transactional
     public void updateSupplement(Long supplementId, SupplementUpdateRequest supplementUpdateRequest) {
         Supplement supplement = supplementRepository.findById(supplementId).orElseThrow(
-                () -> new UserException(ExceptionResponseStatus.INVALID_USER_ID)
+                () -> new SupplementException(ExceptionResponseStatus.INVALID_SUPPLEMENT_ID)
         );
 
         supplement.update(supplementUpdateRequest.getName(), supplementUpdateRequest.getAfterMeal(),
@@ -70,7 +70,7 @@ public class SupplementService {
     @Transactional
     public void deleteSupplement(Long supplementId) {
         Supplement supplement = supplementRepository.findById(supplementId).orElseThrow(
-                () -> new UserException(ExceptionResponseStatus.INVALID_USER_ID)
+                () -> new SupplementException(ExceptionResponseStatus.INVALID_SUPPLEMENT_ID)
         );
 
         supplement.setStatus(Status.INACTIVE);

--- a/src/main/java/com/kuit/healthmate/config/ChatGPTConfig.java
+++ b/src/main/java/com/kuit/healthmate/config/ChatGPTConfig.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
-@Component
+@Configuration
 public class ChatGPTConfig {
     @Value("${openai.api.key}")
     private String openaiApiKey;

--- a/src/main/java/com/kuit/healthmate/config/WebConfig.java
+++ b/src/main/java/com/kuit/healthmate/config/WebConfig.java
@@ -28,7 +28,10 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(jwtAuthenticationInterceptor)
                 .order(1)
-                .addPathPatterns("/login/jwt_test");
+                .addPathPatterns("/supplements/**")
+                .addPathPatterns("/habits/**")
+                .addPathPatterns("/user/**")
+                .addPathPatterns("/challenges/**");
     }
 
     @Override

--- a/src/test/java/com/kuit/healthmate/supplement/SupplementServiceTest.java
+++ b/src/test/java/com/kuit/healthmate/supplement/SupplementServiceTest.java
@@ -15,7 +15,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles("test")
 public class SupplementServiceTest {
 
     @Autowired


### PR DESCRIPTION
### ✏️ 작업 개요
api test를 진행하였습니다. 

### ⛳ 작업 분류
- [x] JwtInterceptor 범위 설정
- [x] 안쓰는 mapper 및 로직 삭제
- [x] @Jwt 붙이기 

### 🔨 작업 상세 내용
1. supplement checker가 없는 경우 supplement를 체크 하지 못하는 문제 해결
2. WebConfig 수정

### 💡 생각해볼 문제
- 카카오톡 알람 시간을 변경할 경우 테이블에 있는 엔티티를 삭제 하여야 하는데, 한 쿼리로 작성 할수 있을 까요? supplement의 86번줄에 다음 코드를 추가해서 기존 supplementTime을 삭제시키고 새로운 애들로 등록하려 하였는데 안되네요. 
~~~ java
        for (SupplementTime supplementTime : supplementTimes) {
            supplementTimes.remove(supplementTime);
        };
~~~